### PR TITLE
Drop Dispatch.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,10 +36,10 @@ scalacOptions  += "-Ywarn-numeric-widen"
 scalacOptions ++= "-Ywarn-unused-import".ifScala211Plus.value.toSeq
 scalacOptions  += "-Ywarn-value-discard"
 
-libraryDependencies += "ch.qos.logback"           % "logback-classic"        % "1.1.3"
-libraryDependencies += "net.databinder.dispatch" %% "dispatch-core"          % "0.11.1"
-libraryDependencies += "net.databinder.dispatch" %% "dispatch-json4s-native" % "0.11.1"
-libraryDependencies += "org.specs2"              %% "specs2"                 % "2.4.2"   % "test"
+libraryDependencies += "ch.qos.logback"  % "logback-classic" % "1.1.3"
+libraryDependencies += "org.json4s"     %% "json4s-core"     % "3.2.9"
+libraryDependencies += "org.json4s"     %% "json4s-native"   % "3.2.9"
+libraryDependencies += "org.specs2"     %% "specs2"          % "2.4.2"  % "test"
 
 typelevelDefaultSettings
 typelevelBuildInfoSettings

--- a/src/main/scala/flumeback/FlumebackAppender.scala
+++ b/src/main/scala/flumeback/FlumebackAppender.scala
@@ -1,8 +1,8 @@
 package flumeback
 
-import ch.qos.logback.classic.pattern.{ThrowableHandlingConverter, ThrowableProxyConverter}
+import ch.qos.logback.classic.pattern.{ ThrowableHandlingConverter, ThrowableProxyConverter }
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.core.{AppenderBase, CoreConstants}
+import ch.qos.logback.core.{ AppenderBase, CoreConstants }
 import dispatch._
 import org.json4s.JsonDSL._
 import org.json4s.ParserUtil

--- a/src/main/scala/flumeback/FlumebackAppender.scala
+++ b/src/main/scala/flumeback/FlumebackAppender.scala
@@ -3,7 +3,6 @@ package flumeback
 import ch.qos.logback.classic.pattern.{ ThrowableHandlingConverter, ThrowableProxyConverter }
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.{ AppenderBase, CoreConstants }
-import dispatch._
 import org.json4s.JsonDSL._
 import org.json4s.ParserUtil
 import org.json4s.native.JsonMethods._
@@ -31,7 +30,6 @@ class FlumebackAppender extends AppenderBase[ILoggingEvent] {
 
   override def stop(): Unit = {
     super.stop()
-    http.shutdown()
     throwableHandlingConverter.stop()
   }
 
@@ -56,13 +54,7 @@ class FlumebackAppender extends AppenderBase[ILoggingEvent] {
         |}]
         |""".stripMargin
 
-    val req = (dispatch
-      .host(host, port)
-      .setContentType("application/json", "UTF-8")
-      << body
-    )
-
-    val resp = http(req)
+    val resp = http.post(host, port, body)
 
     resp onFailure {
       case NonFatal(e) =>

--- a/src/main/scala/flumeback/Http.scala
+++ b/src/main/scala/flumeback/Http.scala
@@ -1,0 +1,34 @@
+package flumeback
+
+import scala.concurrent.{ ExecutionContext, Future }
+import java.net._
+
+trait Http {
+  def post(host: String, port: Int, json: String)(implicit ec: ExecutionContext): Future[Int]
+}
+
+object Http extends Http {
+  def post(host: String, port: Int, json: String)(implicit ec: ExecutionContext): Future[Int] = {
+    Future {
+      val uri = URI.create(s"http://$host:$port/")
+      val url = uri.toURL
+
+      var conn: HttpURLConnection = null
+      try {
+        conn = url.openConnection().asInstanceOf[HttpURLConnection]
+        conn.setRequestProperty("Content-Type", "application/json; charset=UTF-8")
+        conn.setRequestMethod("POST")
+        conn.setDoOutput(true)
+
+        val os = conn.getOutputStream()
+        os.write(json.getBytes("UTF-8"))
+        os.flush()
+        os.close()
+
+        conn.getResponseCode()
+      } finally {
+        if (conn ne null) conn.disconnect()
+      }
+    }
+  }
+}

--- a/src/test/scala/flumeback/FlumebackAppenderSpec.scala
+++ b/src/test/scala/flumeback/FlumebackAppenderSpec.scala
@@ -61,7 +61,7 @@ class FlumebackAppenderSpec extends Specification with ContextFixture {
 case class Context(flumebackAppender: FlumebackAppender, req: AtomicReference[Request]) {
   val now = System.currentTimeMillis()
   val loggerName = s"TestClass@$now"
-  val logger = (LoggerFactory getLogger loggerName).asInstanceOf[Logger]
+  val logger = getLogger(loggerName)
   val currentThreadName = Thread.currentThread.getName
 }
 

--- a/src/test/scala/flumeback/FlumebackAppenderSpec.scala
+++ b/src/test/scala/flumeback/FlumebackAppenderSpec.scala
@@ -1,19 +1,19 @@
 package flumeback
 
 import ch.qos.logback.classic.spi.LoggingEvent
-import ch.qos.logback.classic.{Level, Logger}
+import ch.qos.logback.classic.{ Level, Logger }
 import com.ning.http.client.AsyncHandler.STATE
 import com.ning.http.client._
 import com.ning.http.client.providers.jdk.JDKFuture
 import dispatch.Http
-import org.slf4j.LoggerFactory
 import org.json4s._
 import org.json4s.native.JsonMethods._
-import org.specs2.execute.{AsResult, Result}
+import org.slf4j.LoggerFactory
+import org.specs2.execute.{ AsResult, Result }
 import org.specs2.mutable.Specification
 import org.specs2.specification.FixtureExample
 
-import java.net.{HttpURLConnection, URL}
+import java.net.{ HttpURLConnection, URL }
 import java.util.concurrent.atomic.AtomicReference
 
 class FlumebackAppenderSpec extends Specification with ContextFixture {

--- a/src/test/scala/flumeback/FlumebackAppenderSpec.scala
+++ b/src/test/scala/flumeback/FlumebackAppenderSpec.scala
@@ -2,10 +2,6 @@ package flumeback
 
 import ch.qos.logback.classic.spi.LoggingEvent
 import ch.qos.logback.classic.{ Level, Logger }
-import com.ning.http.client.AsyncHandler.STATE
-import com.ning.http.client._
-import com.ning.http.client.providers.jdk.JDKFuture
-import dispatch.Http
 import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.slf4j.LoggerFactory
@@ -13,7 +9,8 @@ import org.specs2.execute.{ AsResult, Result }
 import org.specs2.mutable.Specification
 import org.specs2.specification.FixtureExample
 
-import java.net.{ HttpURLConnection, URL }
+import scala.concurrent.{ ExecutionContext, Future }
+import java.net.HttpURLConnection.HTTP_OK
 import java.util.concurrent.atomic.AtomicReference
 
 class FlumebackAppenderSpec extends Specification with ContextFixture {
@@ -27,7 +24,7 @@ class FlumebackAppenderSpec extends Specification with ContextFixture {
 
       flumebackAppender doAppend le
 
-      req.get().getStringData ====
+      req.get() ====
         s"""[{
           |  "headers" : {"timestamp":"$now","level":"INFO","threadId":"$currentThreadName","source":"$loggerName"},
           |  "body" : "Hi"
@@ -44,21 +41,21 @@ class FlumebackAppenderSpec extends Specification with ContextFixture {
 
       flumebackAppender doAppend le
 
-      req.get().getStringData ====
+      req.get() ====
         s"""[{
           |  "headers" : {"timestamp":"$now","level":"INFO","threadId":"$currentThreadName","source":"$loggerName"},
           |  "body" : "{\\"a\\":\\"b\\\\c\\"}"
           |}]
           |""".stripMargin
 
-      parse(req.get().getStringData) must beLike {
+      parse(req.get()) must beLike {
         case JArray(List(JObject(List(_, ("body", JString(body)))))) => body ==== msg
       }
     }
   }
 }
 
-case class Context(flumebackAppender: FlumebackAppender, req: AtomicReference[Request]) {
+case class Context(flumebackAppender: FlumebackAppender, req: AtomicReference[String]) {
   val now = System.currentTimeMillis()
   val loggerName = s"TestClass@$now"
   val logger = getLogger(loggerName)
@@ -67,9 +64,9 @@ case class Context(flumebackAppender: FlumebackAppender, req: AtomicReference[Re
 
 trait ContextFixture extends FixtureExample[Context] {
   protected def fixture[R: AsResult](f: (Context) => R): Result = {
-    val req = new AtomicReference[Request]()
+    val req = new AtomicReference[String]()
     val flumebackAppender = new FlumebackAppender
-    flumebackAppender.http = Http(FakeAsyncHttpClient(req))
+    flumebackAppender.http = FakeHttp(req)
     flumebackAppender.start()
 
     try     AsResult(f(Context(flumebackAppender, req)))
@@ -77,24 +74,9 @@ trait ContextFixture extends FixtureExample[Context] {
   }
 }
 
-case class FakeAsyncHttpClient(ref: AtomicReference[Request]) extends AsyncHttpClient {
-  override def executeRequest[T](request: Request, handler: AsyncHandler[T]): ListenableFuture[T] = {
-    ref set request
-    new JDKFuture[T](FakeAsyncHandler(), 0, FakeHttpURLConnection())
+case class FakeHttp(ref: AtomicReference[String]) extends Http {
+  def post(host: String, port: Int, json: String)(implicit ec: ExecutionContext): Future[Int] = {
+    ref set json
+    Future successful HTTP_OK
   }
-}
-
-case class FakeAsyncHandler[T]() extends AsyncHandler[T] {
-  def onThrowable(t: Throwable) = ()
-  def onCompleted()             = null.asInstanceOf[T]
-
-  def onBodyPartReceived(bodyPart: HttpResponseBodyPart)   = STATE.CONTINUE
-  def onStatusReceived(responseStatus: HttpResponseStatus) = STATE.CONTINUE
-  def onHeadersReceived(headers: HttpResponseHeaders)      = STATE.CONTINUE
-}
-
-case class FakeHttpURLConnection() extends HttpURLConnection(new URL("http://google.com")) {
-  def connect(): Unit       = ()
-  def disconnect(): Unit    = ()
-  def usingProxy(): Boolean = false
 }

--- a/src/test/scala/flumeback/package.scala
+++ b/src/test/scala/flumeback/package.scala
@@ -1,0 +1,17 @@
+import ch.qos.logback.classic.{ LoggerContext, Logger }
+import org.slf4j.LoggerFactory
+import org.slf4j.helpers.SubstituteLoggerFactory
+
+package object flumeback {
+  @volatile private var loggingInitialised = false
+
+  def getLogger(loggerName: String): Logger = {
+    while (!loggingInitialised) {
+      LoggerFactory.getILoggerFactory match {
+        case logger: SubstituteLoggerFactory => Thread sleep 100
+        case logger: LoggerContext           => loggingInitialised = true
+      }
+    }
+    LoggerFactory.getLogger(loggerName).asInstanceOf[Logger]
+  }
+}


### PR DESCRIPTION
Dropping use of Dispatch for micro HTTP class, based on the JDK.

This is because there's a binary incompatibility between async-http-client 1.8.x and 1.9.x, which
correspond to what's used in Play 2.3.x and 2.4.x (and it's what Dispatch uses).

Therefore, in order to allow flumeback to be used in either Play versions, it stops using AHC and
Dispatch all together.

This might be done on json4s as well, but it's not an issue at the moment.